### PR TITLE
Improve build scripts and makefiles (custom RANLIB and STRIP prefix)

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,11 +1,16 @@
 # Common makefile helper file
 
+# Allow overriding prefix for strip separately
+ifndef PREFIX_STRIP_USE
+  PREFIX_STRIP := $(PREFIX)
+endif
+
 # Note - := means expand all and save result, = means expand all each time
 AR := $(PREFIX)ar
 CC := $(PREFIX)gcc
 CXX := $(PREFIX)g++
 LD := $(PREFIX)ld
-STRIP := $(PREFIX)strip
+STRIP := $(PREFIX_STRIP)strip
 
 # Get a good guess as to our compile target
 gcc_machine := $(subst -, ,$(shell $(CC) -dumpmachine))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
 set -ue
 
+# The GCC binaries (gcc, g++, etc) can have their name prefixed
+# by specifying a program-prefix option when configuring.
+# https://gcc.gnu.org/install/configure.html
+#   Search above page for "--program-prefix"
+# The prefix allows multiple GCC to be installed and on system PATH.
+# MINGW (Which we use for crosscompilation) uses this option.
+#   x86_64-w64-mingw32- and i686-w64-mingw32-
+# GCC as built by Linux distros usually uses this option.
+#   however the prefixes vary
+
+# Default prefix to "x86_64-linux-gnu-", but allow overriding.
+#   (For example Fedora 25 is noted needing something like "x86_64-redhat-linux-")
+# NOTE: ${x-y} is a bash-ism. differs from portable ${x:-y} if x undefined
+PARAM_GCC_PROGRAM_PREFIX=${PARAM_GCC_PROGRAM_PREFIX-"x86_64-linux-gnu-"}
+PARAM_GCC_PREFIX_RANLIB=${PARAM_GCC_PREFIX_RANLIB-"x86_64-linux-gnu-"}
+PARAM_GCC_PREFIX_STRIP=${PARAM_GCC_PREFIX_STRIP-"x86_64-linux-gnu-"}
+
 CONFIGS=3
-BUILD_MATRIX_PREFIX=("x86_64-w64-mingw32-" "i686-w64-mingw32-" "x86_64-linux-gnu-")
+BUILD_MATRIX_PREFIX=("x86_64-w64-mingw32-" "i686-w64-mingw32-" "${PARAM_GCC_PROGRAM_PREFIX}")
+BUILD_MATRIX_PREFIX_RANLIB=("x86_64-w64-mingw32-" "i686-w64-mingw32-" "${PARAM_GCC_PREFIX_RANLIB}")
+BUILD_MATRIX_PREFIX_STRIP=("x86_64-w64-mingw32-" "i686-w64-mingw32-" "${PARAM_GCC_PREFIX_STRIP}")
 BUILD_MATRIX_ARTIFACT=("pscrypto.dll" "pscrypto.dll" "libpscrypto.so")
 BUILD_MATRIX_JAVA_FOLDER=("win32-x86-64" "win32-x86" "linux-x86-64")
 
@@ -18,10 +37,15 @@ for i in `seq 1 $CONFIGS`; do
    javaFolder=${BUILD_MATRIX_JAVA_FOLDER[$iter]}
 
    export PREFIX=${BUILD_MATRIX_PREFIX[$iter]}
+   export PREFIX_RANLIB=${BUILD_MATRIX_PREFIX_RANLIB[$iter]}
+   export PREFIX_RANLIB_USE=t
+   export PREFIX_STRIP=${BUILD_MATRIX_PREFIX_STRIP[$iter]}
+   export PREFIX_STRIP_USE=t
 
    echo "Now building $javaFolder..."
-   make clean > /dev/null 2>&1
-   make -j > "build-log-${javaFolder}.txt" 2>&1
+   make clean > "build-log-clean-${javaFolder}.txt" 2>&1
+   # -j with no number was LITERALLY causing a system crash (out of memory)
+   make -j 2 > "build-log-${javaFolder}.txt" 2>&1
 
    mkdir -p "$BUILD_DEST/$javaFolder"
    cp "pscrypto/${BUILD_MATRIX_ARTIFACT[$iter]}" "$BUILD_DEST/$javaFolder/"


### PR DESCRIPTION
This Pull Request should be merged _after_ the previous Pull Request for project psf-cryptopp.
(See https://github.com/psforever/psf-cryptopp/pull/1)

Technical details:
- PREFIX_STRIP is introduced, same concept as PREFIX_RANLIB.
  This feature was motivated by attempting to compile the project on a Linux Fedora distro.
  (Which requires a prefix for the strip command, different than the prefix for GCC et al)
- the cryptopp submodule is updated to a revision supporting aforementioned PREFIX_RANLIB
  (thus both become available after merging this Pull Request)
- the build script in scripts/build.sh is augmented with:
  * some comments
  * options for customizing the 'build matrix'. in particular the 3rd column (values of which are used to build for 64-bit linux).
  * RANLIB and STRIP command can now receive a separate prefix.
  * 'make clean' invocation now logs stdout/stderr to a text file, similar to the main 'make' invocation.
  * the main 'make' invocation was being invoked with a parameterless '-j' option.
     this does not work and will exhaust system resources (in particular memory on low memory setups).
     it is now invoked with '-j 2', limiting resource consumption. (but may want to tweak it further, I believe '-j 4' is popular..)
